### PR TITLE
Fix unused imports

### DIFF
--- a/infer.py
+++ b/infer.py
@@ -1,15 +1,11 @@
 # Copyright (c) 2017 NVIDIA Corporation
 import torch
 import argparse
+import copy
 from reco_encoder.data import input_layer
 from reco_encoder.model import model
-import torch.optim as optim
-import torch.nn as nn
 from torch.autograd import Variable
-import copy
-import time
 from pathlib import Path
-import numpy as np
 
 parser = argparse.ArgumentParser(description='RecoEncoder')
 

--- a/reco_encoder/__init__.py
+++ b/reco_encoder/__init__.py
@@ -1,3 +1,1 @@
 # Copyright (c) 2017 NVIDIA Corporation
-from . import data
-from . import model

--- a/reco_encoder/data/__init__.py
+++ b/reco_encoder/data/__init__.py
@@ -1,2 +1,1 @@
 # Copyright (c) 2017 NVIDIA Corporation
-from . import input_layer

--- a/reco_encoder/model/__init__.py
+++ b/reco_encoder/model/__init__.py
@@ -1,3 +1,1 @@
 # Copyright (c) 2017 NVIDIA Corporation
-from .model import AutoEncoder
-from .model import MSEloss

--- a/test/context.py
+++ b/test/context.py
@@ -1,6 +1,0 @@
-# Copyright (c) 2017 NVIDIA Corporation
-import os
-import sys
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
-
-import reco_encoder

--- a/test/data_layer_tests.py
+++ b/test/data_layer_tests.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2017 NVIDIA Corporation
 import unittest
-import sys
-from .context import reco_encoder
+from reco_encoder.data.input_layer import UserItemRecDataProvider
 
 class UserItemRecDataProviderTest(unittest.TestCase):
   def test_1(self):
@@ -9,7 +8,7 @@ class UserItemRecDataProviderTest(unittest.TestCase):
     params = {}
     params['batch_size'] = 64
     params['data_dir'] = 'test/testData_iRec'
-    data_layer = reco_encoder.data.input_layer.UserItemRecDataProvider(params=params)
+    data_layer = UserItemRecDataProvider(params=params)
     print("Total items found: {}".format(len(data_layer.data.keys())))
     self.assertTrue(len(data_layer.data.keys())>0)
 
@@ -17,7 +16,7 @@ class UserItemRecDataProviderTest(unittest.TestCase):
     params = {}
     params['batch_size'] = 32
     params['data_dir'] = 'test/testData_iRec'
-    data_layer = reco_encoder.data.input_layer.UserItemRecDataProvider(params=params)
+    data_layer = UserItemRecDataProvider(params=params)
     print("Total items found: {}".format(len(data_layer.data.keys())))
     for i, data in enumerate(data_layer.iterate_one_epoch()):
       print(i)

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -1,13 +1,12 @@
 # Copyright (c) 2017 NVIDIA Corporation
 import unittest
 import sys
+import torch.optim as optim
+from torch.autograd import Variable
+from reco_encoder.data.input_layer import UserItemRecDataProvider
+from reco_encoder.model.model import AutoEncoder, MSEloss
 sys.path.append('data')
 sys.path.append('model')
-import torch
-from .context import reco_encoder
-import torch.optim as optim
-import torch.nn as nn
-from torch.autograd import Variable
 
 class iRecAutoEncoderTest(unittest.TestCase):
   def test_CPU(self):
@@ -15,11 +14,11 @@ class iRecAutoEncoderTest(unittest.TestCase):
     params = {}
     params['batch_size'] = 64
     params['data_dir'] = 'test/testData_iRec'
-    data_layer = reco_encoder.data.input_layer.UserItemRecDataProvider(params=params)
+    data_layer = UserItemRecDataProvider(params=params)
     print("Vector dim: {}".format(data_layer.vector_dim))
     print("Total items found: {}".format(len(data_layer.data.keys())))
     self.assertTrue(len(data_layer.data.keys())>0)
-    encoder = reco_encoder.model.AutoEncoder(layer_sizes=[data_layer.vector_dim, 256, 128], is_constrained=True)
+    encoder = AutoEncoder(layer_sizes=[data_layer.vector_dim, 256, 128], is_constrained=True)
     print(encoder)
     print(encoder.parameters())
     optimizer = optim.SGD(encoder.parameters(), lr=0.01, momentum=0.9)
@@ -28,7 +27,7 @@ class iRecAutoEncoderTest(unittest.TestCase):
         inputs = Variable(mb.to_dense())
         optimizer.zero_grad()
         outputs = encoder(inputs)
-        loss, num_ratings = reco_encoder.model.MSEloss(outputs, inputs)
+        loss, num_ratings = MSEloss(outputs, inputs)
         loss = loss / num_ratings
         loss.backward()
         optimizer.step()
@@ -39,10 +38,10 @@ class iRecAutoEncoderTest(unittest.TestCase):
     params = {}
     params['batch_size'] = 32
     params['data_dir'] = 'test/testData_iRec'
-    data_layer = reco_encoder.data.input_layer.UserItemRecDataProvider(params=params)
+    data_layer = UserItemRecDataProvider(params=params)
     print("Total items found: {}".format(len(data_layer.data.keys())))
     self.assertTrue(len(data_layer.data.keys()) > 0)
-    encoder = reco_encoder.model.AutoEncoder(layer_sizes=[data_layer.vector_dim, 1024, 512, 512, 512, 512, 128])
+    encoder = AutoEncoder(layer_sizes=[data_layer.vector_dim, 1024, 512, 512, 512, 512, 128])
     encoder.cuda()
     optimizer = optim.Adam(encoder.parameters())
     print(encoder)
@@ -53,7 +52,7 @@ class iRecAutoEncoderTest(unittest.TestCase):
         inputs = Variable(mb.to_dense().cuda())
         optimizer.zero_grad()
         outputs = encoder(inputs)
-        loss, num_ratings = reco_encoder.model.MSEloss(outputs, inputs)
+        loss, num_ratings = MSEloss(outputs, inputs)
         loss = loss / num_ratings
         loss.backward()
         optimizer.step()
@@ -67,18 +66,18 @@ class uRecAutoEncoderTest(unittest.TestCase):
     params = {}
     params['batch_size'] = 256
     params['data_dir'] = 'test/testData_uRec'
-    data_layer = reco_encoder.data.input_layer.UserItemRecDataProvider(params=params)
+    data_layer = UserItemRecDataProvider(params=params)
     print("Vector dim: {}".format(data_layer.vector_dim))
     print("Total items found: {}".format(len(data_layer.data.keys())))
     self.assertTrue(len(data_layer.data.keys())>0)
-    encoder = reco_encoder.model.AutoEncoder(layer_sizes=[data_layer.vector_dim, 128, data_layer.vector_dim])
+    encoder = AutoEncoder(layer_sizes=[data_layer.vector_dim, 128, data_layer.vector_dim])
     optimizer = optim.SGD(encoder.parameters(), lr=0.1, momentum=0.9)
     for epoch in range(1):
       for i, mb in enumerate(data_layer.iterate_one_epoch()):
         inputs = Variable(mb.to_dense())
         optimizer.zero_grad()
         outputs = encoder(inputs)
-        loss, num_ratings = reco_encoder.model.MSEloss(outputs, inputs)
+        loss, num_ratings = MSEloss(outputs, inputs)
         loss = loss / num_ratings
         loss.backward()
         optimizer.step()
@@ -91,10 +90,10 @@ class uRecAutoEncoderTest(unittest.TestCase):
     params = {}
     params['batch_size'] = 64
     params['data_dir'] = 'test/testData_uRec'
-    data_layer = reco_encoder.data.input_layer.UserItemRecDataProvider(params=params)
+    data_layer = UserItemRecDataProvider(params=params)
     print("Total items found: {}".format(len(data_layer.data.keys())))
     self.assertTrue(len(data_layer.data.keys()) > 0)
-    encoder = reco_encoder.model.AutoEncoder(layer_sizes=[data_layer.vector_dim, 1024, 512, 512, 128])
+    encoder = AutoEncoder(layer_sizes=[data_layer.vector_dim, 1024, 512, 512, 128])
     encoder.cuda()
     optimizer = optim.Adam(encoder.parameters())
     print(encoder)
@@ -105,7 +104,7 @@ class uRecAutoEncoderTest(unittest.TestCase):
         inputs = Variable(mb.to_dense().cuda())
         optimizer.zero_grad()
         outputs = encoder(inputs)
-        loss, num_ratings = reco_encoder.model.MSEloss(outputs, inputs)
+        loss, num_ratings = MSEloss(outputs, inputs)
         loss = loss / num_ratings
         loss.backward()
         optimizer.step()


### PR DESCRIPTION
- Remove unused imports
- Remove the need of context.py file (it's quite confusing to use and will throw flake8 / pep8 off)

Unit test log:

(the failures are because of `Torch not compiled with CUDA enabled`)

```
$ python3 -m unittest test/data_layer_tests.py
Test 1 started
Total items found: 163
.Total items found: 163
0
torch.Size([32, 19547])
1
torch.Size([32, 19547])
2
torch.Size([32, 19547])
3
torch.Size([32, 19547])
4
torch.Size([32, 19547])
.
----------------------------------------------------------------------
Ran 2 tests in 0.199s

OK
```

```
$ python3 -m unittest test/test_model.py
iRecAutoEncoderTest Test on  CPU started
Vector dim: 19547
Total items found: 163
******************************
******************************
[19547, 256, 128]
Dropout drop probability: 0.0
Encoder pass:
torch.Size([256, 19547])
torch.Size([256])
torch.Size([128, 256])
torch.Size([128])
Decoder pass:
Decoder is constrained
torch.Size([256, 128])
torch.Size([256])
torch.Size([19547, 256])
torch.Size([19547])
******************************
******************************
AutoEncoder (
  (encode_w): ParameterList (
  )
  (encode_b): ParameterList (
  )
  (decode_b): ParameterList (
  )
)
<generator object Module.parameters at 0x10fefb990>
[0,     0] loss: 13.7627230
[0,     1] loss: 15.5718050
[1,     0] loss: 14.1457729
[1,     1] loss: 14.2564306
[2,     0] loss: 14.7592907
[2,     1] loss: 13.3936634
[3,     0] loss: 13.4373884
[3,     1] loss: 13.8697548
[4,     0] loss: 12.5413427
[4,     1] loss: 13.3834724
[5,     0] loss: 12.0962524
[5,     1] loss: 10.2871866
[6,     0] loss: 11.9361048
[6,     1] loss: 12.7510881
[7,     0] loss: 11.2688084
[7,     1] loss: 8.9151201
[8,     0] loss: 6.6534214
[8,     1] loss: 10.7530689
[9,     0] loss: 5.4654245
[9,     1] loss: 8.7021055
[10,     0] loss: 4.8678174
[10,     1] loss: 8.9395142
[11,     0] loss: 8.0163450
[11,     1] loss: 5.3523836
[12,     0] loss: 4.6805806
[12,     1] loss: 5.7746768
[13,     0] loss: 4.6549287
[13,     1] loss: 4.6210918
[14,     0] loss: 4.5356889
[14,     1] loss: 3.7206159
[15,     0] loss: 3.3543446
[15,     1] loss: 3.7410641
[16,     0] loss: 5.0429521
[16,     1] loss: 2.9728928
[17,     0] loss: 3.3243787
[17,     1] loss: 2.6175928
[18,     0] loss: 2.3361208
[18,     1] loss: 2.8326197
[19,     0] loss: 3.0278883
[19,     1] loss: 2.6812475
.iRecAutoEncoderTest Test on GPU started
Total items found: 163
******************************
******************************
[19547, 1024, 512, 512, 512, 512, 128]
Dropout drop probability: 0.0
Encoder pass:
torch.Size([1024, 19547])
torch.Size([1024])
torch.Size([512, 1024])
torch.Size([512])
torch.Size([512, 512])
torch.Size([512])
torch.Size([512, 512])
torch.Size([512])
torch.Size([512, 512])
torch.Size([512])
torch.Size([128, 512])
torch.Size([128])
Decoder pass:
Decoder is constrained
torch.Size([512, 128])
torch.Size([512])
torch.Size([512, 512])
torch.Size([512])
torch.Size([512, 512])
torch.Size([512])
torch.Size([512, 512])
torch.Size([512])
torch.Size([1024, 512])
torch.Size([1024])
torch.Size([19547, 1024])
torch.Size([19547])
******************************
******************************
FuRecAutoEncoderTest Test on  CPU started
Vector dim: 11259
Total items found: 97618
******************************
******************************
[11259, 128, 11259]
Dropout drop probability: 0.0
Encoder pass:
torch.Size([128, 11259])
torch.Size([128])
torch.Size([11259, 128])
torch.Size([11259])
Decoder pass:
Decoder is constrained
torch.Size([128, 11259])
torch.Size([128])
torch.Size([11259, 128])
torch.Size([11259])
******************************
******************************
[0,     0] loss: 10.4307327
[0,     1] loss: 11.3560009
[0,     2] loss: 10.5129652
[0,     3] loss: 10.8210392
[0,     4] loss: 10.5824280
[0,     5] loss: 9.0050182
.uRecAutoEncoderTest Test on GPU started
Total items found: 97618
******************************
******************************
[11259, 1024, 512, 512, 128]
Dropout drop probability: 0.0
Encoder pass:
torch.Size([1024, 11259])
torch.Size([1024])
torch.Size([512, 1024])
torch.Size([512])
torch.Size([512, 512])
torch.Size([512])
torch.Size([128, 512])
torch.Size([128])
Decoder pass:
Decoder is constrained
torch.Size([512, 128])
torch.Size([512])
torch.Size([512, 512])
torch.Size([512])
torch.Size([1024, 512])
torch.Size([1024])
torch.Size([11259, 1024])
torch.Size([11259])
******************************
******************************
F
======================================================================
FAIL: test_GPU (test.test_model.iRecAutoEncoderTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/intoth3rainbow/Dropbox/GitHub/cabinet/DeepRecommender/test/test_model.py", line 45, in test_GPU
    encoder.cuda()
  File "/usr/local/lib/python3.6/site-packages/torch/nn/modules/module.py", line 147, in cuda
    return self._apply(lambda t: t.cuda(device_id))
  File "/usr/local/lib/python3.6/site-packages/torch/nn/modules/module.py", line 118, in _apply
    module._apply(fn)
  File "/usr/local/lib/python3.6/site-packages/torch/nn/modules/module.py", line 124, in _apply
    param.data = fn(param.data)
  File "/usr/local/lib/python3.6/site-packages/torch/nn/modules/module.py", line 147, in <lambda>
    return self._apply(lambda t: t.cuda(device_id))
  File "/usr/local/lib/python3.6/site-packages/torch/_utils.py", line 66, in _cuda
    return new_type(self.size()).copy_(self, async)
  File "/usr/local/lib/python3.6/site-packages/torch/cuda/__init__.py", line 266, in _lazy_new
    _lazy_init()
  File "/usr/local/lib/python3.6/site-packages/torch/cuda/__init__.py", line 84, in _lazy_init
    _check_driver()
  File "/usr/local/lib/python3.6/site-packages/torch/cuda/__init__.py", line 51, in _check_driver
    raise AssertionError("Torch not compiled with CUDA enabled")
AssertionError: Torch not compiled with CUDA enabled

======================================================================
FAIL: test_GPU (test.test_model.uRecAutoEncoderTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/intoth3rainbow/Dropbox/GitHub/cabinet/DeepRecommender/test/test_model.py", line 97, in test_GPU
    encoder.cuda()
  File "/usr/local/lib/python3.6/site-packages/torch/nn/modules/module.py", line 147, in cuda
    return self._apply(lambda t: t.cuda(device_id))
  File "/usr/local/lib/python3.6/site-packages/torch/nn/modules/module.py", line 118, in _apply
    module._apply(fn)
  File "/usr/local/lib/python3.6/site-packages/torch/nn/modules/module.py", line 124, in _apply
    param.data = fn(param.data)
  File "/usr/local/lib/python3.6/site-packages/torch/nn/modules/module.py", line 147, in <lambda>
    return self._apply(lambda t: t.cuda(device_id))
  File "/usr/local/lib/python3.6/site-packages/torch/_utils.py", line 66, in _cuda
    return new_type(self.size()).copy_(self, async)
  File "/usr/local/lib/python3.6/site-packages/torch/cuda/__init__.py", line 266, in _lazy_new
    _lazy_init()
  File "/usr/local/lib/python3.6/site-packages/torch/cuda/__init__.py", line 84, in _lazy_init
    _check_driver()
  File "/usr/local/lib/python3.6/site-packages/torch/cuda/__init__.py", line 51, in _check_driver
    raise AssertionError("Torch not compiled with CUDA enabled")
AssertionError: Torch not compiled with CUDA enabled

----------------------------------------------------------------------
Ran 4 tests in 7.768s

FAILED (failures=2)
```