### PR TITLE
Make data conversion script respect the output dir it is given

### DIFF
--- a/data_utils/netflix_data_convert.py
+++ b/data_utils/netflix_data_convert.py
@@ -75,13 +75,6 @@ def create_NETFLIX_data_timesplit(all_data,
 
 
 def main(args):
-  # create necessary folders:
-  for output_dir in [
-    "Netflix/N3M_TRAIN", "Netflix/N3M_VALID", "Netflix/N3M_TEST", "Netflix/N6M_TRAIN",
-    "Netflix/N6M_VALID", "Netflix/N6M_TEST", "Netflix/N1Y_TRAIN", "Netflix/N1Y_VALID",
-    "Netflix/N1Y_TEST", "Netflix/NF_TRAIN", "Netflix/NF_VALID", "Netflix/NF_TEST"]:
-    makedirs(output_dir, exist_ok=True)
-
   user2id_map = dict()
   item2id_map = dict()
   userId = 0
@@ -90,6 +83,12 @@ def main(args):
 
   folder = args[1]
   out_folder = args[2]
+  # create necessary folders:
+  for output_dir in [(out_folder + f) for f in [
+    "/N3M_TRAIN", "/N3M_VALID", "/N3M_TEST", "/N6M_TRAIN",
+    "/N6M_VALID", "/N6M_TEST", "/N1Y_TRAIN", "/N1Y_VALID",
+    "/N1Y_TEST", "/NF_TRAIN", "/NF_VALID", "/NF_TEST"]]:
+    makedirs(output_dir, exist_ok=True)
 
   text_files = [path.join(folder, f)
                 for f in listdir(folder)


### PR DESCRIPTION
If one gave other output dir name than 'Netflix', as seemingly supported, data conversion failed at the end of the 1.5 hour processing, due to missing output dirs.